### PR TITLE
Derive `ParseError` from `ValueError`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,8 @@ Unreleased
 * Add project URLs in setup.py (thanks to Steve Piercy)
 * Update README links (thanks to Steve Piercy)
 * Fix handling of README in setup.py (encoding fun in 3.5, 3.6 and pypy3)
-* FIx README links (thanks to Chris Barker)
+* Fix README links (thanks to Chris Barker)
+* Derive `ParseError` from `ValueError`
 
 0.1.13
 ------

--- a/iso8601/iso8601.py
+++ b/iso8601/iso8601.py
@@ -67,7 +67,7 @@ ISO8601_REGEX = re.compile(
     re.VERBOSE
 )
 
-class ParseError(Exception):
+class ParseError(ValueError):
     """Raised when there is a problem parsing a date string"""
 
 if sys.version_info >= (3, 2, 0):

--- a/iso8601/iso8601.pyi
+++ b/iso8601/iso8601.pyi
@@ -36,7 +36,7 @@ else:
 ISO8601_REGEX: Pattern[basestring] = ...
 
 
-class ParseError(Exception):
+class ParseError(ValueError):
 
     ...
 


### PR DESCRIPTION
Brings it more in line with stdlib behaviours, eg strptime or json.loads