### PR TITLE
Add is_iso8601() function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,10 @@ Python 3 versions < 3.6 are untested but should work.
 Changes
 =======
 
+unreleased
+----------
+* Add `is_iso8601` function for validating that a string matches an ISO 8601 format
+
 1.0.2
 -----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,8 @@ To install simply use pip::
 API
 ===
 
+.. autofunction:: iso8601.is_iso8601
+
 .. autofunction:: iso8601.parse_date
 
 .. autoexception:: iso8601.ParseError

--- a/iso8601/__init__.py
+++ b/iso8601/__init__.py
@@ -1,3 +1,3 @@
 from .iso8601 import UTC, FixedOffset, ParseError, is_iso8601, parse_date
 
-__all__ = ["parse_date", "is_iso8601" "ParseError", "UTC", "FixedOffset"]
+__all__ = ["parse_date", "is_iso8601", "ParseError", "UTC", "FixedOffset"]

--- a/iso8601/__init__.py
+++ b/iso8601/__init__.py
@@ -1,3 +1,3 @@
-from .iso8601 import UTC, FixedOffset, ParseError, parse_date
+from .iso8601 import UTC, FixedOffset, ParseError, is_iso8601, parse_date
 
-__all__ = ["parse_date", "ParseError", "UTC", "FixedOffset"]
+__all__ = ["parse_date", "is_iso8601" "ParseError", "UTC", "FixedOffset"]

--- a/iso8601/iso8601.py
+++ b/iso8601/iso8601.py
@@ -147,3 +147,16 @@ def parse_date(
         )
     except Exception as e:
         raise ParseError(e)
+
+
+def is_iso8601(datestring: str) -> bool:
+    """Check if a string matches an ISO 8601 format.
+
+    :param datestring: The string to check for validity
+    :returns: True if the string matches an ISO 8601 format, False otherwise
+    """
+    try:
+        m = ISO8601_REGEX.match(datestring)
+        return bool(m)
+    except Exception:
+        return False

--- a/iso8601/iso8601.py
+++ b/iso8601/iso8601.py
@@ -158,5 +158,5 @@ def is_iso8601(datestring: str) -> bool:
     try:
         m = ISO8601_REGEX.match(datestring)
         return bool(m)
-    except Exception:
-        return False
+    except Exception as e:
+        raise ParseError(e)

--- a/iso8601/test_iso8601.py
+++ b/iso8601/test_iso8601.py
@@ -60,6 +60,7 @@ def test_parse_utc_different_default() -> None:
     ],
 )
 def test_parse_invalid_date(invalid_date: str, error_string: str) -> None:
+    assert iso8601.is_iso8601(invalid_date) is False
     with pytest.raises(iso8601.ParseError) as exc:
         iso8601.parse_date(invalid_date)
     assert exc.errisinstance(iso8601.ParseError)
@@ -243,6 +244,7 @@ def test_parse_invalid_date(invalid_date: str, error_string: str) -> None:
 def test_parse_valid_date(
     valid_date: str, expected_datetime: datetime.datetime, isoformat: str
 ) -> None:
+    assert iso8601.is_iso8601(valid_date) is True
     parsed = iso8601.parse_date(valid_date)
     assert parsed.year == expected_datetime.year
     assert parsed.month == expected_datetime.month


### PR DESCRIPTION
Sometimes, a developer wants to validate that a particular string matches the ISO 8601 format, without actually caring about the _value_ of the parsed result. In such cases, it's a waste of computer cycles to actually construct the `datetime.datetime` object; it's more efficient to just return a boolean. Currently, the most effective way to do this is to rely on a non-public, undocumented interface, like this:

```python
from iso8601.iso8601 import ISO8601_REGEX
is_valid = bool(ISO8601_REGEX.match(my_str))
```

It would be better if there was a public, documented, tested interface for accomplishing this use-case. Hence, this pull request adds a function named `is_iso8601()` to the project, and exports it as a public, documented function in this library. That way, developers can use this code instead, which is much more readable:

```python
from iso8601 import is_iso8601
is_valid = is_iso8601(my_str)
```

Note that because this pull request adds a new feature to this library, it should also increment the minor version, according to semantic versioning. I am happy to do that in this pull request, in a separate one, or let a maintainer handle that instead.